### PR TITLE
allow react to route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm run build
 # Production stage
 FROM nginx:stable-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY custom_nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 

--- a/custom_nginx.conf
+++ b/custom_nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
# allow react to route instead of nginx

- nginx was 404ing on /game
- now we need to serve a catchall 404 page from react for anything not routed in index.jsx